### PR TITLE
MacOS-friendly iconv syntax

### DIFF
--- a/pg_hunspell_install
+++ b/pg_hunspell_install
@@ -51,7 +51,7 @@ else
 		if [ ! -e "./temp/$IDENTIFIER.utf8.$ext" ]; then
 			## Download and convert to UTF-8 from $ENCODING
 			wget --no-verbose "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/$IDENTIFIER/$IDENTIFIER.$ext" -O - |
-			iconv -f "$ENCODING" -t utf8 -o "./temp/$IDENTIFIER.utf8.$ext";
+			iconv -f "$ENCODING" -t utf8 > "./temp/$IDENTIFIER.utf8.$ext";
 		fi;
 	done;
 fi


### PR DESCRIPTION
It seems that iconv's `-o` option is [not supported on OS X](https://www.unix.com/man-page/mojave/1/iconv/). Maybe `>` would be better?